### PR TITLE
Use API_PREFIX in API service calls

### DIFF
--- a/src/services/api.js
+++ b/src/services/api.js
@@ -15,8 +15,9 @@ const RAW_API_PREFIX = import.meta?.env?.VITE_API_PREFIX || "/api";
 const BASE_URL = String(RAW_BASE_URL).replace(/\/+$/, "");
 const API_PREFIX = ("/" + String(RAW_API_PREFIX || "").replace(/^\/+/, "")).replace(/\/+$/, "");
 
-// base final: https://.../api
-const FINAL_BASE_URL = `${BASE_URL}${API_PREFIX}`;
+// base final: https://...
+// OBS: o prefixo da API (ex.: /api) será adicionado manualmente nas chamadas
+const FINAL_BASE_URL = `${BASE_URL || ""}`; // sem /api fixo
 
 console.log("[API] FINAL_BASE_URL =", FINAL_BASE_URL);
 
@@ -75,11 +76,13 @@ api.interceptors.response.use(
     const status = error?.response?.status;
     if (status === 401) {
       // limpa tokens locais (se existirem)
-      try {
-        localStorage.removeItem("token");
-        localStorage.removeItem("authToken");
-        localStorage.removeItem("accessToken");
-      } catch {}
+        try {
+          localStorage.removeItem("token");
+          localStorage.removeItem("authToken");
+          localStorage.removeItem("accessToken");
+        } catch {
+          /* ignore token removal errors */
+        }
 
       // deixa o App decidir o que fazer:
       if (typeof window !== "undefined") {

--- a/src/services/categoriasApi.js
+++ b/src/services/categoriasApi.js
@@ -1,22 +1,22 @@
 // src/services/categoriasApi.js
-import api from "./api";
+import api, { API_PREFIX } from "./api";
 
 export async function listarCategorias() {
-  const { data } = await api.get("/categorias");
+  const { data } = await api.get(`${API_PREFIX}/categorias`);
   return data;
 }
 
 export async function adicionarCategoria(nome) {
-  const { data } = await api.post("/categorias", { nome });
+  const { data } = await api.post(`${API_PREFIX}/categorias`, { nome });
   return data;
 }
 
 export async function deletarCategoria(id) {
-  const resp = await api.delete(`/categorias/${id}`);
+  const resp = await api.delete(`${API_PREFIX}/categorias/${id}`);
   return resp.status === 200 || resp.status === 204;
 }
 
 export async function editarCategoria(id, novoNome) {
-  const { data } = await api.put(`/categorias/${id}`, { nome: novoNome });
+  const { data } = await api.put(`${API_PREFIX}/categorias/${id}`, { nome: novoNome });
   return data;
 }

--- a/src/services/marcasApi.js
+++ b/src/services/marcasApi.js
@@ -1,22 +1,22 @@
 // src/services/marcasApi.js
-import api from "./api"; // <- usa o cliente axios central
+import api, { API_PREFIX } from "./api"; // <- usa o cliente axios central
 
 export async function listarMarcas() {
-  const { data } = await api.get("/marcas");
+  const { data } = await api.get(`${API_PREFIX}/marcas`);
   return data;
 }
 
 export async function adicionarMarca(nome) {
-  const { data } = await api.post("/marcas", { nome });
+  const { data } = await api.post(`${API_PREFIX}/marcas`, { nome });
   return data;
 }
 
 export async function deletarMarca(id) {
-  const resp = await api.delete(`/marcas/${id}`);
+  const resp = await api.delete(`${API_PREFIX}/marcas/${id}`);
   return resp.status === 200 || resp.status === 204;
 }
 
 export async function editarMarca(id, novoNome) {
-  const { data } = await api.put(`/marcas/${id}`, { nome: novoNome });
+  const { data } = await api.put(`${API_PREFIX}/marcas/${id}`, { nome: novoNome });
   return data;
 }


### PR DESCRIPTION
## Summary
- decouple API base URL from fixed /api prefix
- include API_PREFIX in categoriasApi and marcasApi requests

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: React hook and unused variable errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68afbc740e288333ae31a87f59bb2694