### PR TITLE
Frontend: use API_PREFIX in all routes and remove /api from baseURL

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, createContext, useContext } from "react";
-import api from "./services/api";
+import api, { API_PREFIX } from "./services/api";
 import Perfil from "./components/Perfil";
 import Configuracoes from "./components/Configuracoes";
 import Custos from "./components/Custos/Custos";
@@ -158,7 +158,7 @@ export default function App() {
     let canceled = false;
     async function fetchUser() {
       try {
-        const res = await api.get("/users/me");
+        const res = await api.get(`${API_PREFIX}/users/me`);
         if (!canceled) setUser(res.data);
       } catch {
         if (!canceled) setUser(null);
@@ -175,7 +175,7 @@ export default function App() {
     if (!user) return;
     async function fetchFuncionarios() {
       try {
-        const res = await api.get("/folhapagamento/funcionarios");
+        const res = await api.get(`${API_PREFIX}/folhapagamento/funcionarios`);
         setCategoriasCustos(cats => {
           const novas = [...cats];
           novas[1].funcionarios = Array.isArray(res.data) ? res.data : [];
@@ -194,7 +194,7 @@ export default function App() {
 
   async function handleAddFuncionario(novoFuncionario) {
     try {
-      const { data } = await api.post("/folhapagamento/funcionarios", novoFuncionario);
+      const { data } = await api.post(`${API_PREFIX}/folhapagamento/funcionarios`, novoFuncionario);
       setCategoriasCustos(cats => {
         const novas = [...cats];
         novas[1].funcionarios = [...novas[1].funcionarios, data];
@@ -209,7 +209,7 @@ export default function App() {
   async function handleEditarFuncionario(idx, funcionarioEditado) {
     try {
       const id = categoriasCustos[1].funcionarios[idx].id;
-      const { data } = await api.put(`/folhapagamento/funcionarios/${id}`, funcionarioEditado);
+      const { data } = await api.put(`${API_PREFIX}/folhapagamento/funcionarios/${id}`, funcionarioEditado);
       setCategoriasCustos(cats => {
         const novas = [...cats];
         novas[1].funcionarios = novas[1].funcionarios.map((f, i) => (i === idx ? data : f));
@@ -224,7 +224,7 @@ export default function App() {
   async function handleExcluirFuncionario(idx) {
     try {
       const id = categoriasCustos[1].funcionarios[idx].id;
-      await api.delete(`/folhapagamento/funcionarios/${id}`);
+      await api.delete(`${API_PREFIX}/folhapagamento/funcionarios/${id}`);
       setCategoriasCustos(cats => {
         const novas = [...cats];
         novas[1].funcionarios = novas[1].funcionarios.filter((_, i) => i !== idx);
@@ -249,7 +249,7 @@ export default function App() {
     e.preventDefault();
     setMsg("Enviando...");
     try {
-      const { data } = await api.post("/users", {
+      const { data } = await api.post(`${API_PREFIX}/users`, {
         name: form.name,
         email: form.email,
         password: form.password
@@ -272,7 +272,7 @@ export default function App() {
     e.preventDefault();
     setMsg("Entrando...");
     try {
-      const { data } = await api.post("/users/login", {
+      const { data } = await api.post(`${API_PREFIX}/users/login`, {
         email: form.email,
         password: form.password
       });
@@ -293,7 +293,7 @@ export default function App() {
 
   async function handleLogout() {
     try {
-      await api.post("/users/logout");
+      await api.post(`${API_PREFIX}/users/logout`);
     } catch {}
     // limpa o header em memória
     try {

--- a/src/components/Custos/DespesasFixas.jsx
+++ b/src/components/Custos/DespesasFixas.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from "react";
 import { FiEdit2, FiTrash2, FiCheck, FiX } from "react-icons/fi";
 import ConfirmDeleteModal from "../modals/ConfirmDeleteModal";
 import ModalDespesasFixas from "./ModalDespesasFixas";
+import { API_PREFIX } from "../../services/api";
 import "./DespesasFixas.css";
 
 export default function DespesasFixas() {
@@ -15,7 +16,7 @@ export default function DespesasFixas() {
   const [modalDelete, setModalDelete] = useState({ open: false, idx: null });
 
   useEffect(() => {
-    fetch('http://localhost:3000/api/despesasfixas/subcategorias', { credentials: 'include' })
+    fetch(`${API_PREFIX}/despesasfixas/subcategorias`, { credentials: 'include' })
       .then(res => res.json())
       .then(data => setSubcategorias(Array.isArray(data) ? data : []))
       .catch(() => setSubcategorias([]));
@@ -32,7 +33,7 @@ export default function DespesasFixas() {
 
   async function handleAddSubcat() {
     try {
-      const res = await fetch('http://localhost:3000/api/despesasfixas/subcategorias', {
+      const res = await fetch(`${API_PREFIX}/despesasfixas/subcategorias`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
@@ -52,7 +53,7 @@ export default function DespesasFixas() {
     if (!nomeSubcatTemp.trim()) return;
     const subcat = subcategorias[idx];
     try {
-      const res = await fetch(`http://localhost:3000/api/despesasfixas/subcategorias/${subcat.id}`, {
+      const res = await fetch(`${API_PREFIX}/despesasfixas/subcategorias/${subcat.id}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
@@ -75,7 +76,7 @@ export default function DespesasFixas() {
   async function handleApagarSubcat(idx) {
     const subcat = subcategorias[idx];
     try {
-      await fetch(`http://localhost:3000/api/despesasfixas/subcategorias/${subcat.id}`, {
+      await fetch(`${API_PREFIX}/despesasfixas/subcategorias/${subcat.id}`, {
         method: 'DELETE',
         credentials: 'include'
       });
@@ -97,7 +98,7 @@ export default function DespesasFixas() {
     const valorNumber = Number(String(despesa.valor).replace(/\./g, "").replace(",", "."));
     try {
       if (editandoDespesaIdx === "novo") {
-        const res = await fetch(`http://localhost:3000/api/despesasfixas/subcategorias/${subcat.id}/custos`, {
+        const res = await fetch(`${API_PREFIX}/despesasfixas/subcategorias/${subcat.id}/custos`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           credentials: 'include',
@@ -111,7 +112,7 @@ export default function DespesasFixas() {
         }
       } else {
         const custo = subcategorias[subcatIdx].fixedCosts[editandoDespesaIdx];
-        const res = await fetch(`http://localhost:3000/api/despesasfixas/custos/${custo.id}`, {
+        const res = await fetch(`${API_PREFIX}/despesasfixas/custos/${custo.id}`, {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
           credentials: 'include',
@@ -145,7 +146,7 @@ export default function DespesasFixas() {
   async function handleExcluirDespesa(idx) {
     const custo = subcategorias[subcatIdx].fixedCosts[idx];
     try {
-      await fetch(`http://localhost:3000/api/despesasfixas/custos/${custo.id}`, {
+      await fetch(`${API_PREFIX}/despesasfixas/custos/${custo.id}`, {
         method: 'DELETE',
         credentials: 'include'
       });

--- a/src/components/Custos/EncargosSobreVenda.jsx
+++ b/src/components/Custos/EncargosSobreVenda.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import axios from "axios";
+import api, { API_PREFIX } from "../../services/api";
 import "./EncargosSobreVenda.css";
 
 // SECTIONS dos blocos tradicionais:
@@ -103,7 +103,7 @@ export default function EncargosSobreVenda() {
     async function fetchData() {
       setLoading(true);
       try {
-        const res = await axios.get("http://localhost:3000/api/encargos-sobre-venda", { withCredentials: true });
+        const res = await api.get(`${API_PREFIX}/encargos-sobre-venda`, { withCredentials: true });
         if (res.data && res.data.data) {
           setData(res.data.data || INITIAL_DATA);
           setOutros(res.data.outros || []);
@@ -124,7 +124,7 @@ export default function EncargosSobreVenda() {
     if (loading) return;
     async function saveData() {
       try {
-        await axios.post("http://localhost:3000/api/encargos-sobre-venda", { data, outros }, { withCredentials: true });
+        await api.post(`${API_PREFIX}/encargos-sobre-venda`, { data, outros }, { withCredentials: true });
       } catch (err) { }
     }
     saveData();

--- a/src/components/Custos/FolhaDePagamento.jsx
+++ b/src/components/Custos/FolhaDePagamento.jsx
@@ -3,7 +3,7 @@ import { useEffect, useState, useRef, useCallback } from "react";
 import { FaTrashAlt } from "react-icons/fa";
 import "./FolhaDePagamento.css";
 import ModalFuncionario from "./ModalFuncionario";
-import api from "../../services/api";
+import api, { API_PREFIX } from "../../services/api";
 
 /* ===== utils de formatação ===== */
 function parseBR(str) {
@@ -106,7 +106,7 @@ export default function FolhaDePagamento() {
     (async () => {
       setLoading(true);
       try {
-        const { data } = await api.get("/folhapagamento/funcionarios", { withCredentials: true });
+        const { data } = await api.get(`${API_PREFIX}/folhapagamento/funcionarios`, { withCredentials: true });
         setFuncionarios(Array.isArray(data) ? data : []);
       } catch {
         setFuncionarios([]);
@@ -170,7 +170,7 @@ export default function FolhaDePagamento() {
     try {
       if (editando === null) {
         const { data: novo } = await api.post(
-          "/folhapagamento/funcionarios",
+          `${API_PREFIX}/folhapagamento/funcionarios`,
           funcionarioTemp,
           { withCredentials: true }
         );
@@ -178,7 +178,7 @@ export default function FolhaDePagamento() {
       } else {
         const id = funcionarios[editando].id;
         const { data: atualizado } = await api.put(
-          `/folhapagamento/funcionarios/${id}`,
+          `${API_PREFIX}/folhapagamento/funcionarios/${id}`,
           funcionarioTemp,
           { withCredentials: true }
         );
@@ -194,7 +194,7 @@ export default function FolhaDePagamento() {
   async function excluirFuncionario(idx) {
     try {
       const id = funcionarios[idx].id;
-      await api.delete(`/folhapagamento/funcionarios/${id}`, { withCredentials: true });
+      await api.delete(`${API_PREFIX}/folhapagamento/funcionarios/${id}`, { withCredentials: true });
       setFuncionarios((prev) => prev.filter((f) => f.id !== id));
     } catch {
       alert("Não foi possível excluir o funcionário.");

--- a/src/components/Estoque/Cadastro.jsx
+++ b/src/components/Estoque/Cadastro.jsx
@@ -11,7 +11,7 @@ import { listarMarcas, adicionarMarca } from "../../services/marcasApi";
 import { listarCategorias, adicionarCategoria } from "../../services/categoriasApi";
 import * as XLSX from "xlsx";
 import { saveAs } from "file-saver";
-import api from "../../services/api";
+import api, { API_PREFIX } from "../../services/api";
 
 // ================== helpers ==================
 function toStr(v, { joinAll = false } = {}) {
@@ -133,7 +133,7 @@ export default function Cadastro() {
   // Preferências (rota sem :userId)
   async function fetchColunasPreferidas() {
     try {
-      const { data } = await api.get("/preferencias/colunas-cadastro");
+      const { data } = await api.get(`${API_PREFIX}/preferencias/colunas-cadastro`);
       if (Array.isArray(data) && data.length > 0) setColunasPreferidas(data);
       else setColunasPreferidas(null);
     } catch {
@@ -144,7 +144,7 @@ export default function Cadastro() {
   async function fetchProdutos() {
     setLoading(true);
     try {
-      const { data } = await api.get("/produtos");
+      const { data } = await api.get(`${API_PREFIX}/produtos`);
       setIngredientes(Array.isArray(data) ? data : []);
     } catch {
       setIngredientes([]);
@@ -248,10 +248,10 @@ export default function Cadastro() {
     try {
       let produtoSalvo;
       if (id) {
-        const { data } = await api.put(`/produtos/${id}`, payload);
+        const { data } = await api.put(`${API_PREFIX}/produtos/${id}`, payload);
         produtoSalvo = data;
       } else {
-        const { data } = await api.post("/produtos", payload);
+        const { data } = await api.post(`${API_PREFIX}/produtos`, payload);
         produtoSalvo = data;
       }
 
@@ -283,7 +283,7 @@ export default function Cadastro() {
       return;
     }
     try {
-      await api.delete(`/produtos/${itemDelete.id}`);
+      await api.delete(`${API_PREFIX}/produtos/${itemDelete.id}`);
       setIngredientes(prev => prev.filter(item => item.id !== itemDelete.id));
     } catch (err) {
       alert("Erro ao excluir produto!");
@@ -322,7 +322,7 @@ export default function Cadastro() {
         }
       }
 
-      const { data: result } = await api.post("/produtos/importar", { produtos });
+      const { data: result } = await api.post(`${API_PREFIX}/produtos/importar`, { produtos });
       if (result.erros && result.erros.length > 0) {
         alert(
           "Alguns produtos não foram importados:\n" +
@@ -370,7 +370,7 @@ export default function Cadastro() {
   async function handleToggleAtivo(item) {
     setAtivandoId(item.id);
     try {
-      const { data: produtoAtualizado } = await api.put(`/produtos/${item.id}`, {
+      const { data: produtoAtualizado } = await api.put(`${API_PREFIX}/produtos/${item.id}`, {
         ...item,
         ativo: !item.ativo,
       });

--- a/src/components/Estoque/EntradaEstoque.jsx
+++ b/src/components/Estoque/EntradaEstoque.jsx
@@ -4,6 +4,7 @@ import ModalCadastroFornecedor from "./ModalCadastroFornecedor";
 import ModalUpgradePlano from "../modals/ModalUpgradePlano";
 import { useAuth } from "../../App";
 import Select from "react-select";
+import { API_PREFIX } from "../../services/api";
 import "./EntradaEstoque.css";
 
 // ====== ESTILO REACT-SELECT ======
@@ -127,7 +128,7 @@ export default function EntradaEstoque() {
 
   // Buscar produtos do backend
   useEffect(() => {
-    fetch("/api/produtos")
+    fetch(`${API_PREFIX}/produtos`)
       .then(res => res.json())
       .then(data => setProdutos(data))
       .catch(() => setMsg("Erro ao buscar produtos"));
@@ -135,7 +136,7 @@ export default function EntradaEstoque() {
 
   // Buscar fornecedores do backend
   useEffect(() => {
-    fetch("/api/fornecedores", { credentials: "include" })
+    fetch(`${API_PREFIX}/fornecedores`, { credentials: "include" })
       .then(res => res.json())
       .then(data => setFornecedores(data));
   }, []);
@@ -222,7 +223,7 @@ export default function EntradaEstoque() {
     try {
       for (const entrada of listaFinal) {
         if (!entrada.produtoId || !entrada.quantidade) continue;
-        await fetch("/api/produtos/entrada-estoque", {
+        await fetch(`${API_PREFIX}/produtos/entrada-estoque`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(entrada)
@@ -430,12 +431,12 @@ export default function EntradaEstoque() {
           ingrediente={novoProduto}
           onSave={async (novoProd) => {
             try {
-              await fetch("/api/produtos", {
+              await fetch(`${API_PREFIX}/produtos`, {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify(novoProd),
               });
-              const data = await fetch("/api/produtos").then(r => r.json());
+              const data = await fetch(`${API_PREFIX}/produtos`).then(r => r.json());
               setProdutos(data);
             } catch {
               alert("Erro ao cadastrar produto!");
@@ -483,12 +484,12 @@ export default function EntradaEstoque() {
               fornecedor={novoFornecedor}
               onSave={async (novoForn) => {
                 try {
-                  await fetch("/api/fornecedores", {
+                  await fetch(`${API_PREFIX}/fornecedores`, {
                     method: "POST",
                     headers: { "Content-Type": "application/json" },
                     body: JSON.stringify(novoForn),
                   });
-                  const data = await fetch("/api/fornecedores", { credentials: "include" }).then(r => r.json());
+                  const data = await fetch(`${API_PREFIX}/fornecedores`, { credentials: "include" }).then(r => r.json());
                   setFornecedores(data);
                   // Seleciona automaticamente o novo
                   const criado = data.find(f => f.cnpjCpf === novoForn.cnpjCpf && f.razaoSocial === novoForn.razaoSocial);

--- a/src/components/Estoque/Fornecedores.jsx
+++ b/src/components/Estoque/Fornecedores.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from "react";
 import ModalCadastroFornecedor from "./ModalCadastroFornecedor";
 import ModalUpgradePlano from "../modals/ModalUpgradePlano";
 import { useAuth } from "../../App";
+import { API_PREFIX } from "../../services/api";
 import "./Fornecedores.css";
 
 export default function Fornecedores() {
@@ -32,7 +33,7 @@ export default function Fornecedores() {
   const [carregando, setCarregando] = useState(true);
   const [confirmExcluirIdx, setConfirmExcluirIdx] = useState(null);
 
-  const API = "/api/fornecedores";
+  const API = `${API_PREFIX}/fornecedores`;
 
   useEffect(() => {
     fetch(API, { credentials: "include" })

--- a/src/components/Estoque/ImportarNotaFiscalXML.jsx
+++ b/src/components/Estoque/ImportarNotaFiscalXML.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { API_PREFIX } from "../../services/api";
 
 export default function ImportarNotaFiscalXML({ onUpload }) {
   const [file, setFile] = useState(null);
@@ -21,7 +22,7 @@ export default function ImportarNotaFiscalXML({ onUpload }) {
     const formData = new FormData();
     formData.append("xml", file);
     try {
-      const res = await fetch("/api/produtos/importar-xml-nfe", {
+      const res = await fetch(`${API_PREFIX}/produtos/importar-xml-nfe`, {
         method: "POST",
         body: formData
       });

--- a/src/components/Estoque/ModalCadastroManual.jsx
+++ b/src/components/Estoque/ModalCadastroManual.jsx
@@ -9,6 +9,7 @@ import Select from "react-select";
 import { FaCog, FaPlus, FaEdit, FaTrash, FaCheck, FaTimes } from "react-icons/fa";
 import "./ModalCadastroManual.css";
 import { BsInfoCircle } from "react-icons/bs";
+import { API_PREFIX } from "../../services/api";
 
 function formatarDataBR(dataStr) {
   if (!dataStr) return "";
@@ -108,7 +109,7 @@ async function buscarImagensPexels(nome, page = 1) {
 async function buscarNomePorCodigoBarras(codBarras) {
   if (!codBarras) return "";
   try {
-    const res = await fetch(`/api/buscar-nome-codbarras/${codBarras}`);
+    const res = await fetch(`${API_PREFIX}/buscar-nome-codbarras/${codBarras}`);
     if (!res.ok) return "";
     const data = await res.json();
     return data.nome || "";
@@ -241,7 +242,7 @@ export default function ModalCadastroManual({
   // Busca as opções SEMPRE que abrir o modal OU trocar para aba de rótulo
   useEffect(() => {
     if (open && abaBloco === "rotulo") {
-      fetch("/api/categorias-nutricionais", { credentials: "include" })
+      fetch(`${API_PREFIX}/categorias-nutricionais`, { credentials: "include" })
         .then(res => res.json())
         .then(data => setCategoriasNutricionais(Array.isArray(data) ? data : []));
     }
@@ -443,7 +444,7 @@ export default function ModalCadastroManual({
   useEffect(() => {
     if (abaBloco === "historico" && ingrediente?.id) {
       setLoadingEntradas(true);
-      fetch(`/api/produtos/${ingrediente.id}/entradas`, { credentials: "include" })
+      fetch(`${API_PREFIX}/produtos/${ingrediente.id}/entradas`, { credentials: "include" })
         .then(res => res.json())
         .then(data => setEntradas(Array.isArray(data) ? data : []))
         .catch(() => setEntradas([]))

--- a/src/components/Estoque/ModalConfiguracoesCadastro.jsx
+++ b/src/components/Estoque/ModalConfiguracoesCadastro.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from "react";
 import Modal from "react-modal";
 import { FiX } from "react-icons/fi";
 import { DragDropContext, Droppable, Draggable } from "@hello-pangea/dnd";
-import api from "../../services/api"; // <-- usa o axios central
+import api, { API_PREFIX } from "../../services/api"; // <-- usa o axios central
 
 // Switch azul igual o do app
 function Switch({ checked, onChange }) {
@@ -59,7 +59,7 @@ export default function ModalConfiguracoesCadastro({ isOpen, onRequestClose }) {
 
     const userId = localStorage.getItem("user_id") || "1";
     api
-      .get(`/preferencias/colunas-cadastro/${userId}`)
+      .get(`${API_PREFIX}/preferencias/colunas-cadastro/${userId}`)
       .then(({ data }) => {
         if (Array.isArray(data) && data.length > 0)
           setColunas(data);
@@ -107,7 +107,7 @@ export default function ModalConfiguracoesCadastro({ isOpen, onRequestClose }) {
     setErro("");
     try {
       const userId = localStorage.getItem("user_id") || "1";
-      await api.post("/preferencias/colunas-cadastro", { userId, colunas });
+      await api.post(`${API_PREFIX}/preferencias/colunas-cadastro`, { userId, colunas });
       alert("Preferências salvas! (Agora no banco 😁)");
       onRequestClose();
     } catch (e) {

--- a/src/components/Estoque/Movimentacoes.jsx
+++ b/src/components/Estoque/Movimentacoes.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import Select from "react-select";
 import ModalUpgradePlano from "../modals/ModalUpgradePlano";
 import { useAuth } from "../../App";
+import { API_PREFIX } from "../../services/api";
 import "./Movimentacoes.css";
 
 // Estilo dos selects igual aos inputs do sistema
@@ -144,7 +145,7 @@ export default function Movimentacoes() {
   // Busca movimentações
   function buscarMovs() {
     setCarregando(true);
-    fetch("/api/movimentacoes", { credentials: "include" })
+    fetch(`${API_PREFIX}/movimentacoes`, { credentials: "include" })
       .then(res => res.json())
       .then(data => setMovs(data))
       .finally(() => setCarregando(false));
@@ -155,7 +156,7 @@ export default function Movimentacoes() {
   }, []);
 
   useEffect(() => {
-    fetch("/api/produtos", { credentials: "include" })
+    fetch(`${API_PREFIX}/produtos`, { credentials: "include" })
       .then(res => res.json())
       .then(setProdutos);
   }, []);
@@ -176,7 +177,7 @@ export default function Movimentacoes() {
 
     setDeletando(mov.id);
     try {
-      const rota = `/api/movimentacoes/${mov.tipo === "entrada" ? "entrada" : "saida"}/${mov.id}`;
+      const rota = `${API_PREFIX}/movimentacoes/${mov.tipo === "entrada" ? "entrada" : "saida"}/${mov.id}`;
       const res = await fetch(rota, { method: "DELETE", credentials: "include" });
       if (!res.ok) throw new Error("Erro ao deletar movimentação");
       buscarMovs();

--- a/src/components/Estoque/SaidaEstoque.jsx
+++ b/src/components/Estoque/SaidaEstoque.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from "react";
 import Select from "react-select";
 import ModalUpgradePlano from "../modals/ModalUpgradePlano";
 import { useAuth } from "../../App";
+import { API_PREFIX } from "../../services/api";
 import "./EntradaEstoque.css"; // Usa o mesmo CSS global do restante
 
 // ====== ESTILO REACT-SELECT (azul/padrão do app) ======
@@ -110,7 +111,7 @@ export default function SaidaEstoque() {
   const [carregando, setCarregando] = useState(false);
 
   useEffect(() => {
-    fetch("/api/produtos")
+    fetch(`${API_PREFIX}/produtos`)
       .then(res => res.json())
       .then(data => setProdutos(data))
       .catch(() => setMsg("Erro ao buscar produtos"));
@@ -183,7 +184,7 @@ export default function SaidaEstoque() {
     try {
       for (const saida of listaFinal) {
         if (!saida.produtoId || !saida.quantidade) continue;
-        await fetch("/api/produtos/saida-estoque", {
+        await fetch(`${API_PREFIX}/produtos/saida-estoque`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           credentials: "include",

--- a/src/components/Markup/MarkupIdeal.jsx
+++ b/src/components/Markup/MarkupIdeal.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import axios from "axios";
+import api, { API_PREFIX } from "../../services/api";
 import AbasModal from "./AbasModal";
 import DespesasFixasModal from "./DespesasFixasModal";
 import EncargosSobreVendaModal from "./EncargosSobreVendaModal";
@@ -552,8 +552,8 @@ export default function MarkupIdeal({ calcularTotalFuncionarioObj }) {
     );
 
     try {
-      await axios.put(
-        `/api/markup-ideal/${bloco.id}`,
+      await api.put(
+        `${API_PREFIX}/markup-ideal/${bloco.id}`,
         {
           markup: bloco.markup,
           markupIdeal: markupIdeal,
@@ -574,7 +574,7 @@ export default function MarkupIdeal({ calcularTotalFuncionarioObj }) {
   useEffect(() => {
     async function fetchFiltro() {
       try {
-        const res = await axios.get("/api/filtro-faturamento", { withCredentials: true });
+        const res = await api.get(`${API_PREFIX}/filtro-faturamento`, { withCredentials: true });
         if (res.data?.filtro) {
           setMediaTipo(res.data.filtro);
         } else {
@@ -589,7 +589,7 @@ export default function MarkupIdeal({ calcularTotalFuncionarioObj }) {
   useEffect(() => {
     async function fetchFaturamentos() {
       try {
-        const res = await axios.get("/api/sales-results", { withCredentials: true });
+        const res = await api.get(`${API_PREFIX}/sales-results`, { withCredentials: true });
         const lista = Array.isArray(res.data) ? res.data : [];
         setFaturamentoLista(lista);
         let listaFiltrada = mediaTipo === "all" ? lista : lista.slice(-Number(mediaTipo));
@@ -609,7 +609,7 @@ export default function MarkupIdeal({ calcularTotalFuncionarioObj }) {
   useEffect(() => {
     async function fetchBlocos() {
       try {
-        const response = await axios.get("/api/markup-ideal", { withCredentials: true });
+        const response = await api.get(`${API_PREFIX}/markup-ideal`, { withCredentials: true });
         setBlocos(Array.isArray(response.data) ? response.data : []);
       } catch (err) {
         setBlocos([]);
@@ -617,7 +617,7 @@ export default function MarkupIdeal({ calcularTotalFuncionarioObj }) {
     }
     async function fetchDespesasFixas() {
       try {
-        const res = await axios.get("/api/despesasfixas", { withCredentials: true });
+        const res = await api.get(`${API_PREFIX}/despesasfixas`, { withCredentials: true });
         if (Array.isArray(res.data)) {
           setDespesasFixasSubcats(res.data);
         } else if (res.data && Array.isArray(res.data.categorias)) {
@@ -640,7 +640,7 @@ export default function MarkupIdeal({ calcularTotalFuncionarioObj }) {
     }
     async function fetchFuncionarios() {
       try {
-        const res = await axios.get("/api/folhapagamento/funcionarios", { withCredentials: true });
+        const res = await api.get(`${API_PREFIX}/folhapagamento/funcionarios`, { withCredentials: true });
         setFuncionarios(Array.isArray(res.data) ? res.data : []);
       } catch (err) {
         setFuncionarios([]);
@@ -653,7 +653,7 @@ export default function MarkupIdeal({ calcularTotalFuncionarioObj }) {
   useEffect(() => {
     async function fetchEncargos() {
       try {
-        const res = await axios.get("/api/encargos-sobre-venda", { withCredentials: true });
+        const res = await api.get(`${API_PREFIX}/encargos-sobre-venda`, { withCredentials: true });
         if (res.data) {
           setEncargos(res.data);
           if (Array.isArray(res.data.outros)) setOutrosEncargos(res.data.outros);
@@ -669,7 +669,7 @@ export default function MarkupIdeal({ calcularTotalFuncionarioObj }) {
   useEffect(() => {
     async function fetchEncargos() {
       try {
-        const res = await axios.get("/api/encargos-sobre-venda", { withCredentials: true });
+        const res = await api.get(`${API_PREFIX}/encargos-sobre-venda`, { withCredentials: true });
         if (res.data) {
           setEncargos(res.data);
           if (Array.isArray(res.data.outros)) setOutrosEncargos(res.data.outros);
@@ -690,7 +690,7 @@ export default function MarkupIdeal({ calcularTotalFuncionarioObj }) {
       const ativosPorBloco = {};
       await Promise.all(blocos.map(async (bloco, idx) => {
         try {
-          const res = await axios.get(`/api/bloco-ativos/${bloco.id}`, { withCredentials: true });
+          const res = await api.get(`${API_PREFIX}/bloco-ativos/${bloco.id}`, { withCredentials: true });
           ativosPorBloco[idx] = res.data.ativos || {};
         } catch {
           ativosPorBloco[idx] = {};
@@ -705,7 +705,7 @@ export default function MarkupIdeal({ calcularTotalFuncionarioObj }) {
       if (modalConfigIdx === null || !blocos[modalConfigIdx]) return;
       const blocoId = blocos[modalConfigIdx].id;
       try {
-        const res = await axios.get(`/api/bloco-ativos/${blocoId}`, { withCredentials: true });
+        const res = await api.get(`${API_PREFIX}/bloco-ativos/${blocoId}`, { withCredentials: true });
         setCustosAtivosPorBloco(prev => ({
           ...prev,
           [modalConfigIdx]: res.data.ativos || {}
@@ -758,8 +758,8 @@ export default function MarkupIdeal({ calcularTotalFuncionarioObj }) {
         observacoes: "",
         totalEncargosReais: totalEncargosReais,
       };
-      const response = await axios.post(
-        "/api/markup-ideal",
+      const response = await api.post(
+        `${API_PREFIX}/markup-ideal`,
         blocoCompleto,
         { withCredentials: true }
       );
@@ -856,8 +856,8 @@ export default function MarkupIdeal({ calcularTotalFuncionarioObj }) {
     try {
       const bloco = blocos[idx];
       if (!bloco?.id) return;
-      await axios.put(
-        `/api/markup-ideal/${bloco.id}`,
+      await api.put(
+        `${API_PREFIX}/markup-ideal/${bloco.id}`,
         { nome: novoNome },
         { withCredentials: true }
       );
@@ -877,8 +877,8 @@ export default function MarkupIdeal({ calcularTotalFuncionarioObj }) {
     if (idx == null) return;
     const bloco = blocos[idx];
     try {
-      await axios.delete(
-        `/api/markup-ideal/${bloco.id}`,
+      await api.delete(
+        `${API_PREFIX}/markup-ideal/${bloco.id}`,
         { withCredentials: true }
       );
       setBlocos(blocos => blocos.filter((_, i) => i !== idx));
@@ -911,11 +911,11 @@ export default function MarkupIdeal({ calcularTotalFuncionarioObj }) {
       outrosEncargos || []
     );
     try {
-      await axios.post(`/api/bloco-ativos/${blocoId}`,
+      await api.post(`${API_PREFIX}/bloco-ativos/${blocoId}`,
         { ativos: custosAtivosEdicao },
         { withCredentials: true }
       );
-      await axios.put(`/api/markup-ideal/${blocoId}`,
+      await api.put(`${API_PREFIX}/markup-ideal/${blocoId}`,
         { totalEncargosReais },
         { withCredentials: true }
       );

--- a/src/components/Perfil.jsx
+++ b/src/components/Perfil.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import api, { BASE_URL } from "../services/api";
+import api, { API_PREFIX, BASE_URL } from "../services/api";
 import ModalToast from "./modals/ModalToast";
 import PerfilLoginSenha from "./PerfilLoginSenha";
 import Cropper from "react-easy-crop";
@@ -235,7 +235,7 @@ export default function Perfil({ onLogout, abaInicial }) {
     async function fetchUser() {
       setLoading(true);
       try {
-        const { data } = await api.get("/users/me");
+        const { data } = await api.get(`${API_PREFIX}/users/me`);
         const avatar = pickAvatarFrom(data);
         setUser({ ...data, avatarUrl: avatar });
         setAvatarPreview(avatar || null);
@@ -257,7 +257,7 @@ export default function Perfil({ onLogout, abaInicial }) {
           semNumero: false,
         };
 
-        const resConfig = await api.get("/company-config");
+        const resConfig = await api.get(`${API_PREFIX}/company-config`);
         if (resConfig.data) {
           novoForm = {
             ...novoForm,
@@ -299,7 +299,7 @@ export default function Perfil({ onLogout, abaInicial }) {
     // Faz o upload
     const formData = new FormData();
     formData.append("avatar", cropped.blob, "avatar.png");
-    const { data } = await api.post("/users/me/avatar", formData, {
+    const { data } = await api.post(`${API_PREFIX}/users/me/avatar`, formData, {
       headers: { "Content-Type": "multipart/form-data" },
     });
 
@@ -378,13 +378,13 @@ export default function Perfil({ onLogout, abaInicial }) {
     setEditando(false);
     setLoading(true);
     try {
-      await api.put("/users/me", {
+      await api.put(`${API_PREFIX}/users/me`, {
         name: form.nome,
         cpf: form.cpf,
         telefone: form.telefone,
       });
 
-      await api.post("/company-config", {
+      await api.post(`${API_PREFIX}/company-config`, {
         companyName: form.empresaNome,
         cnpj: form.cnpj,
         phone: form.telefoneEmpresa,
@@ -426,7 +426,7 @@ export default function Perfil({ onLogout, abaInicial }) {
     try {
       // vamos salvar como caminho de frontend (/avatars/XYZ.png)
       const chosen = `/avatars/${preset.id}`;
-      await api.put("/users/me", { avatarUrl: chosen });
+      await api.put(`${API_PREFIX}/users/me`, { avatarUrl: chosen });
       setUser((prev) => ({ ...prev, avatarUrl: chosen }));
       setAvatarPreview(chosen);
       setToastMsg("Avatar atualizado!");

--- a/src/components/PerfilLoginSenha.jsx
+++ b/src/components/PerfilLoginSenha.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import api from "../services/api";
+import api, { API_PREFIX } from "../services/api";
 
 export default function PerfilLoginSenha({ email }) {
   const [senha, setSenha] = useState("");
@@ -24,7 +24,7 @@ export default function PerfilLoginSenha({ email }) {
     }
 
     try {
-      const { data } = await api.post("/users/change-password", {
+      const { data } = await api.post(`${API_PREFIX}/users/change-password`, {
         senhaNova: senha,
       });
 

--- a/src/components/QuadroDeReceitas/AbaComposicaoReceita.jsx
+++ b/src/components/QuadroDeReceitas/AbaComposicaoReceita.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 import Select from "react-select";
 import { FaTrash } from "react-icons/fa";
 import "./AbaComposicaoReceita.css";
-import api from "../../services/api"; // <-- usa o cliente central (injeta Authorization)
+import api, { API_PREFIX } from "../../services/api"; // <-- usa o cliente central (injeta Authorization)
 
 function formatarCustoUn(custo, unidade) {
   const val = Number(custo);
@@ -69,7 +69,7 @@ export default function AbaComposicaoReceita({
 
   async function fetchProdutosEstoque() {
     try {
-      const { data } = await api.get("/produtos");
+      const { data } = await api.get(`${API_PREFIX}/produtos`);
       setProdutosEstoque(Array.isArray(data) ? data : []);
     } catch {
       setProdutosEstoque([]);
@@ -78,7 +78,7 @@ export default function AbaComposicaoReceita({
 
   async function fetchTodasReceitas() {
     try {
-      const { data } = await api.get("/receitas"); // baseURL já é /api
+      const { data } = await api.get(`${API_PREFIX}/receitas`); // baseURL já é /api
       setTodasReceitas(Array.isArray(data) ? data : []);
     } catch {
       setTodasReceitas([]);

--- a/src/components/QuadroDeReceitas/AbaProjecaoReceita.jsx
+++ b/src/components/QuadroDeReceitas/AbaProjecaoReceita.jsx
@@ -1,4 +1,5 @@
 import React, { useRef, useState, useEffect } from "react";
+import { API_PREFIX } from "../../services/api";
 import { FaPlus, FaEdit, FaTrash, FaCalendarAlt } from "react-icons/fa";
 import "./AbaProjecaoReceita.css";
 
@@ -106,7 +107,7 @@ export default function AbaProjecaoReceita({
 
   async function fetchTiposProduto() {
     try {
-      const res = await fetch("/api/receitas/tipos-produto", { credentials: "include" });
+      const res = await fetch(`${API_PREFIX}/receitas/tipos-produto`, { credentials: "include" });
       const data = await res.json();
       setTiposProduto(
         Array.isArray(data)
@@ -120,7 +121,7 @@ export default function AbaProjecaoReceita({
 
   async function handleAddTipo(novoNome) {
     try {
-      const res = await fetch("/api/receitas/tipos-produto", {
+      const res = await fetch(`${API_PREFIX}/receitas/tipos-produto`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         credentials: "include",
@@ -141,7 +142,7 @@ export default function AbaProjecaoReceita({
     const tipo = tiposProduto[idx];
     if (!tipo) return;
     try {
-      const res = await fetch(`/api/receitas/tipos-produto/${tipo.value}`, {
+      const res = await fetch(`${API_PREFIX}/receitas/tipos-produto/${tipo.value}`, {
         method: "DELETE",
         credentials: "include",
       });
@@ -186,7 +187,7 @@ export default function AbaProjecaoReceita({
   }
   async function fetchProfissoesDiretas() {
     try {
-      const res = await fetch("/api/folhapagamento/funcionarios/profissoes-diretas", { credentials: "include" });
+      const res = await fetch(`${API_PREFIX}/folhapagamento/funcionarios/profissoes-diretas`, { credentials: "include" });
       const data = await res.json();
       setProfissoesDiretas(Array.isArray(data) ? data.map(cargo => ({ value: cargo, label: cargo })) : []);
     } catch (error) {
@@ -195,7 +196,7 @@ export default function AbaProjecaoReceita({
   }
   async function fetchCargosValorHora() {
     try {
-      const res = await fetch("/api/folhapagamento/funcionarios", { credentials: "include" });
+      const res = await fetch(`${API_PREFIX}/folhapagamento/funcionarios`, { credentials: "include" });
       const data = await res.json();
       const cargos = Array.isArray(data) ? data.map(f => ({ cargo: f.cargo, valorHora: calcularValorHoraFuncionario(f) })) : [];
       setCargosComValorHora(cargos);

--- a/src/components/QuadroDeReceitas/CentralReceitas.jsx
+++ b/src/components/QuadroDeReceitas/CentralReceitas.jsx
@@ -11,13 +11,12 @@ import { pdf } from "@react-pdf/renderer";
 import FichaTecnicaPDF from "./FichaTecnicaPDF";
 import ModalUpgradePlano from "../modals/ModalUpgradePlano";
 import { useAuth } from "../../App";
+import { API_PREFIX, BASE_URL } from "../../services/api";
 import "./CentralReceitas.css";
 
 /** Bases do backend vindas do .env */
-const BACKEND_URL =
-  import.meta.env.VITE_BACKEND_URL || "http://localhost:3000"; // usado para servir /uploads
-const API_BASE = `${BACKEND_URL}${import.meta.env.VITE_API_PREFIX || ""}`; // usado para rotas da API (/api)
-const api = (path) => `${API_BASE}${path}`;
+const BACKEND_URL = BASE_URL || import.meta.env.VITE_BACKEND_URL || "http://localhost:3000"; // usado para servir /uploads
+const api = (path) => `${BACKEND_URL}${path}`;
 
 const ABAS = [
   { label: "Composição", componente: AbaComposicaoReceita },
@@ -144,14 +143,14 @@ export default function CentralReceitas() {
 
   async function fetchReceitas() {
     try {
-      const res = await fetch(api("/receitas"), { credentials: "include" });
+      const res = await fetch(api(`${API_PREFIX}/receitas`), { credentials: "include" });
       if (res.ok) setReceitas(await res.json());
     } catch {}
   }
 
   async function fetchBlocosMarkup() {
     try {
-      const res = await fetch(api("/markup-ideal"), { credentials: "include" });
+      const res = await fetch(api(`${API_PREFIX}/markup-ideal`), { credentials: "include" });
       if (res.ok) setBlocosMarkup(await res.json());
     } catch {
       setBlocosMarkup([]);
@@ -160,10 +159,10 @@ export default function CentralReceitas() {
 
   async function fetchPerfil() {
     try {
-      const resUser = await fetch(api("/users/me"), { credentials: "include" });
+      const resUser = await fetch(api(`${API_PREFIX}/users/me`), { credentials: "include" });
       const user = resUser.ok ? await resUser.json() : {};
 
-      const resConfig = await fetch(api("/company-config"), { credentials: "include" });
+      const resConfig = await fetch(api(`${API_PREFIX}/company-config`), { credentials: "include" });
       const empresa = resConfig.ok ? await resConfig.json() : {};
 
       setPerfil({
@@ -223,7 +222,7 @@ export default function CentralReceitas() {
   async function confirmarDelete() {
     if (!receitaPraDeletar) return;
     try {
-      const res = await fetch(api(`/receitas/${receitaPraDeletar.id}`), {
+      const res = await fetch(api(`${API_PREFIX}/receitas/${receitaPraDeletar.id}`), {
         method: "DELETE",
         credentials: "include",
       });
@@ -403,7 +402,7 @@ export default function CentralReceitas() {
     if (selecionados.length === 0) return;
     for (const id of selecionados) {
       try {
-        await fetch(api(`/receitas/${id}`), { method: "DELETE", credentials: "include" });
+        await fetch(api(`${API_PREFIX}/receitas/${id}`), { method: "DELETE", credentials: "include" });
       } catch {}
     }
     await fetchReceitas();
@@ -485,14 +484,14 @@ export default function CentralReceitas() {
     try {
       let res;
       if (editandoId) {
-        res = await fetch(api(`/receitas/${editandoId}`), {
+        res = await fetch(api(`${API_PREFIX}/receitas/${editandoId}`), {
           method: "PUT",
           headers: { "Content-Type": "application/json" },
           credentials: "include",
           body: JSON.stringify(dadosReceita),
         });
       } else {
-        res = await fetch(api(`/receitas`), {
+        res = await fetch(api(`${API_PREFIX}/receitas`), {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           credentials: "include",

--- a/src/components/Sugestoes/Sugestoes.jsx
+++ b/src/components/Sugestoes/Sugestoes.jsx
@@ -1,7 +1,7 @@
 // src/pages/Sugestoes.jsx
 import React, { useState, useEffect } from "react";
+import { API_PREFIX } from "../../services/api";
 
-const API_PREFIX = "/api";
 const BACKEND_URL = import.meta.env.VITE_BACKEND_URL || "http://localhost:3000";
 
 export default function Sugestoes() {

--- a/src/components/TabelaPlanos.jsx
+++ b/src/components/TabelaPlanos.jsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState } from "react";
-import axios from "axios";
+import api, { API_PREFIX } from "../services/api";
 
 // IDs de planos do Mercado Pago (exemplo; ajuste conforme seu backend)
 const planosMensal = {
@@ -64,8 +64,8 @@ export default function TabelaPlanos({ userEmail }) {
 
     try {
       setLoading(true);
-      const { data } = await axios.post(
-        "/api/mercadopago/criar-assinatura",
+      const { data } = await api.post(
+        `${API_PREFIX}/mercadopago/criar-assinatura`,
         { email, planoId },
         { withCredentials: true }
       );

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -1,6 +1,6 @@
 // src/context/AuthContext.jsx
 import React, { createContext, useContext, useEffect, useState, useMemo } from "react";
-import api from "../services/api"; // se seu alias "@" estiver configurado, pode usar "@/services/api"
+import api, { API_PREFIX } from "../services/api"; // se seu alias "@" estiver configurado, pode usar "@/services/api"
 
 const AuthContext = createContext({
   user: null,
@@ -17,7 +17,7 @@ export function AuthProvider({ children }) {
   // Busca o usuário logado no mount
   const loadMe = async () => {
     try {
-      const { data } = await api.get("/users/me");
+      const { data } = await api.get(`${API_PREFIX}/users/me`);
       setUser(data);
     } catch (err) {
       setUser(null);
@@ -33,7 +33,7 @@ export function AuthProvider({ children }) {
 
   // Faz login, salva token e atualiza o usuário
   const login = async (email, password) => {
-    const { data } = await api.post("/users/login", { email, password });
+    const { data } = await api.post(`${API_PREFIX}/users/login`, { email, password });
     // salva o token para o interceptor injetar nos próximos requests
     try {
       localStorage.setItem("token", data?.token || "");
@@ -45,7 +45,7 @@ export function AuthProvider({ children }) {
   // Faz logout no backend e limpa o token local
   const logout = async () => {
     try {
-      await api.post("/users/logout");
+      await api.post(`${API_PREFIX}/users/logout`);
     } catch {}
     try {
       localStorage.removeItem("token");


### PR DESCRIPTION
## Summary
- remove hardcoded `/api` from axios base URL
- prefix all client and fetch requests with `API_PREFIX`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: React hooks/order and unused vars)*

------
https://chatgpt.com/codex/tasks/task_e_68b0463817908333b6fec50fd6f5c551