### PR TITLE
refactor: centralize api url

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, createContext, useContext } from "react";
-import api, { API_PREFIX } from "./services/api";
+import api, { API_URL } from "./services/api";
 import Perfil from "./components/Perfil";
 import Configuracoes from "./components/Configuracoes";
 import Custos from "./components/Custos/Custos";
@@ -158,7 +158,7 @@ export default function App() {
     let canceled = false;
     async function fetchUser() {
       try {
-        const res = await api.get(`${API_PREFIX}/users/me`);
+        const res = await api.get(`${API_URL}/users/me`);
         if (!canceled) setUser(res.data);
       } catch {
         if (!canceled) setUser(null);
@@ -175,7 +175,7 @@ export default function App() {
     if (!user) return;
     async function fetchFuncionarios() {
       try {
-        const res = await api.get(`${API_PREFIX}/folhapagamento/funcionarios`);
+        const res = await api.get(`${API_URL}/folhapagamento/funcionarios`);
         setCategoriasCustos(cats => {
           const novas = [...cats];
           novas[1].funcionarios = Array.isArray(res.data) ? res.data : [];
@@ -194,7 +194,7 @@ export default function App() {
 
   async function handleAddFuncionario(novoFuncionario) {
     try {
-      const { data } = await api.post(`${API_PREFIX}/folhapagamento/funcionarios`, novoFuncionario);
+      const { data } = await api.post(`${API_URL}/folhapagamento/funcionarios`, novoFuncionario);
       setCategoriasCustos(cats => {
         const novas = [...cats];
         novas[1].funcionarios = [...novas[1].funcionarios, data];
@@ -209,7 +209,7 @@ export default function App() {
   async function handleEditarFuncionario(idx, funcionarioEditado) {
     try {
       const id = categoriasCustos[1].funcionarios[idx].id;
-      const { data } = await api.put(`${API_PREFIX}/folhapagamento/funcionarios/${id}`, funcionarioEditado);
+      const { data } = await api.put(`${API_URL}/folhapagamento/funcionarios/${id}`, funcionarioEditado);
       setCategoriasCustos(cats => {
         const novas = [...cats];
         novas[1].funcionarios = novas[1].funcionarios.map((f, i) => (i === idx ? data : f));
@@ -224,7 +224,7 @@ export default function App() {
   async function handleExcluirFuncionario(idx) {
     try {
       const id = categoriasCustos[1].funcionarios[idx].id;
-      await api.delete(`${API_PREFIX}/folhapagamento/funcionarios/${id}`);
+      await api.delete(`${API_URL}/folhapagamento/funcionarios/${id}`);
       setCategoriasCustos(cats => {
         const novas = [...cats];
         novas[1].funcionarios = novas[1].funcionarios.filter((_, i) => i !== idx);
@@ -249,7 +249,7 @@ export default function App() {
     e.preventDefault();
     setMsg("Enviando...");
     try {
-      const { data } = await api.post(`${API_PREFIX}/users`, {
+      const { data } = await api.post(`${API_URL}/users`, {
         name: form.name,
         email: form.email,
         password: form.password
@@ -272,7 +272,7 @@ export default function App() {
     e.preventDefault();
     setMsg("Entrando...");
     try {
-      const { data } = await api.post(`${API_PREFIX}/users/login`, {
+      const { data } = await api.post(`${API_URL}/users/login`, {
         email: form.email,
         password: form.password
       });
@@ -293,7 +293,7 @@ export default function App() {
 
   async function handleLogout() {
     try {
-      await api.post(`${API_PREFIX}/users/logout`);
+      await api.post(`${API_URL}/users/logout`);
     } catch {}
     // limpa o header em memória
     try {

--- a/src/components/Custos/DespesasFixas.jsx
+++ b/src/components/Custos/DespesasFixas.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from "react";
 import { FiEdit2, FiTrash2, FiCheck, FiX } from "react-icons/fi";
 import ConfirmDeleteModal from "../modals/ConfirmDeleteModal";
 import ModalDespesasFixas from "./ModalDespesasFixas";
-import { API_PREFIX } from "../../services/api";
+import { API_URL } from "../../services/api";
 import "./DespesasFixas.css";
 
 export default function DespesasFixas() {
@@ -16,7 +16,7 @@ export default function DespesasFixas() {
   const [modalDelete, setModalDelete] = useState({ open: false, idx: null });
 
   useEffect(() => {
-    fetch(`${API_PREFIX}/despesasfixas/subcategorias`, { credentials: 'include' })
+    fetch(`${API_URL}/despesasfixas/subcategorias`, { credentials: 'include' })
       .then(res => res.json())
       .then(data => setSubcategorias(Array.isArray(data) ? data : []))
       .catch(() => setSubcategorias([]));
@@ -33,7 +33,7 @@ export default function DespesasFixas() {
 
   async function handleAddSubcat() {
     try {
-      const res = await fetch(`${API_PREFIX}/despesasfixas/subcategorias`, {
+      const res = await fetch(`${API_URL}/despesasfixas/subcategorias`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
@@ -53,7 +53,7 @@ export default function DespesasFixas() {
     if (!nomeSubcatTemp.trim()) return;
     const subcat = subcategorias[idx];
     try {
-      const res = await fetch(`${API_PREFIX}/despesasfixas/subcategorias/${subcat.id}`, {
+      const res = await fetch(`${API_URL}/despesasfixas/subcategorias/${subcat.id}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
@@ -76,7 +76,7 @@ export default function DespesasFixas() {
   async function handleApagarSubcat(idx) {
     const subcat = subcategorias[idx];
     try {
-      await fetch(`${API_PREFIX}/despesasfixas/subcategorias/${subcat.id}`, {
+      await fetch(`${API_URL}/despesasfixas/subcategorias/${subcat.id}`, {
         method: 'DELETE',
         credentials: 'include'
       });
@@ -98,7 +98,7 @@ export default function DespesasFixas() {
     const valorNumber = Number(String(despesa.valor).replace(/\./g, "").replace(",", "."));
     try {
       if (editandoDespesaIdx === "novo") {
-        const res = await fetch(`${API_PREFIX}/despesasfixas/subcategorias/${subcat.id}/custos`, {
+        const res = await fetch(`${API_URL}/despesasfixas/subcategorias/${subcat.id}/custos`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           credentials: 'include',
@@ -112,7 +112,7 @@ export default function DespesasFixas() {
         }
       } else {
         const custo = subcategorias[subcatIdx].fixedCosts[editandoDespesaIdx];
-        const res = await fetch(`${API_PREFIX}/despesasfixas/custos/${custo.id}`, {
+        const res = await fetch(`${API_URL}/despesasfixas/custos/${custo.id}`, {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
           credentials: 'include',
@@ -146,7 +146,7 @@ export default function DespesasFixas() {
   async function handleExcluirDespesa(idx) {
     const custo = subcategorias[subcatIdx].fixedCosts[idx];
     try {
-      await fetch(`${API_PREFIX}/despesasfixas/custos/${custo.id}`, {
+      await fetch(`${API_URL}/despesasfixas/custos/${custo.id}`, {
         method: 'DELETE',
         credentials: 'include'
       });

--- a/src/components/Custos/EncargosSobreVenda.jsx
+++ b/src/components/Custos/EncargosSobreVenda.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import api, { API_PREFIX } from "../../services/api";
+import api, { API_URL } from "../../services/api";
 import "./EncargosSobreVenda.css";
 
 // SECTIONS dos blocos tradicionais:
@@ -103,7 +103,7 @@ export default function EncargosSobreVenda() {
     async function fetchData() {
       setLoading(true);
       try {
-        const res = await api.get(`${API_PREFIX}/encargos-sobre-venda`, { withCredentials: true });
+        const res = await api.get(`${API_URL}/encargos-sobre-venda`, { withCredentials: true });
         if (res.data && res.data.data) {
           setData(res.data.data || INITIAL_DATA);
           setOutros(res.data.outros || []);
@@ -124,7 +124,7 @@ export default function EncargosSobreVenda() {
     if (loading) return;
     async function saveData() {
       try {
-        await api.post(`${API_PREFIX}/encargos-sobre-venda`, { data, outros }, { withCredentials: true });
+        await api.post(`${API_URL}/encargos-sobre-venda`, { data, outros }, { withCredentials: true });
       } catch (err) { }
     }
     saveData();

--- a/src/components/Custos/FolhaDePagamento.jsx
+++ b/src/components/Custos/FolhaDePagamento.jsx
@@ -3,7 +3,7 @@ import { useEffect, useState, useRef, useCallback } from "react";
 import { FaTrashAlt } from "react-icons/fa";
 import "./FolhaDePagamento.css";
 import ModalFuncionario from "./ModalFuncionario";
-import api, { API_PREFIX } from "../../services/api";
+import api, { API_URL } from "../../services/api";
 
 /* ===== utils de formatação ===== */
 function parseBR(str) {
@@ -106,7 +106,7 @@ export default function FolhaDePagamento() {
     (async () => {
       setLoading(true);
       try {
-        const { data } = await api.get(`${API_PREFIX}/folhapagamento/funcionarios`, { withCredentials: true });
+        const { data } = await api.get(`${API_URL}/folhapagamento/funcionarios`, { withCredentials: true });
         setFuncionarios(Array.isArray(data) ? data : []);
       } catch {
         setFuncionarios([]);
@@ -170,7 +170,7 @@ export default function FolhaDePagamento() {
     try {
       if (editando === null) {
         const { data: novo } = await api.post(
-          `${API_PREFIX}/folhapagamento/funcionarios`,
+          `${API_URL}/folhapagamento/funcionarios`,
           funcionarioTemp,
           { withCredentials: true }
         );
@@ -178,7 +178,7 @@ export default function FolhaDePagamento() {
       } else {
         const id = funcionarios[editando].id;
         const { data: atualizado } = await api.put(
-          `${API_PREFIX}/folhapagamento/funcionarios/${id}`,
+          `${API_URL}/folhapagamento/funcionarios/${id}`,
           funcionarioTemp,
           { withCredentials: true }
         );
@@ -194,7 +194,7 @@ export default function FolhaDePagamento() {
   async function excluirFuncionario(idx) {
     try {
       const id = funcionarios[idx].id;
-      await api.delete(`${API_PREFIX}/folhapagamento/funcionarios/${id}`, { withCredentials: true });
+      await api.delete(`${API_URL}/folhapagamento/funcionarios/${id}`, { withCredentials: true });
       setFuncionarios((prev) => prev.filter((f) => f.id !== id));
     } catch {
       alert("Não foi possível excluir o funcionário.");

--- a/src/components/Estoque/Cadastro.jsx
+++ b/src/components/Estoque/Cadastro.jsx
@@ -11,7 +11,7 @@ import { listarMarcas, adicionarMarca } from "../../services/marcasApi";
 import { listarCategorias, adicionarCategoria } from "../../services/categoriasApi";
 import * as XLSX from "xlsx";
 import { saveAs } from "file-saver";
-import api, { API_PREFIX } from "../../services/api";
+import api, { API_URL } from "../../services/api";
 
 // ================== helpers ==================
 function toStr(v, { joinAll = false } = {}) {
@@ -133,7 +133,7 @@ export default function Cadastro() {
   // Preferências (rota sem :userId)
   async function fetchColunasPreferidas() {
     try {
-      const { data } = await api.get(`${API_PREFIX}/preferencias/colunas-cadastro`);
+      const { data } = await api.get(`${API_URL}/preferencias/colunas-cadastro`);
       if (Array.isArray(data) && data.length > 0) setColunasPreferidas(data);
       else setColunasPreferidas(null);
     } catch {
@@ -144,7 +144,7 @@ export default function Cadastro() {
   async function fetchProdutos() {
     setLoading(true);
     try {
-      const { data } = await api.get(`${API_PREFIX}/produtos`);
+      const { data } = await api.get(`${API_URL}/produtos`);
       setIngredientes(Array.isArray(data) ? data : []);
     } catch {
       setIngredientes([]);
@@ -248,10 +248,10 @@ export default function Cadastro() {
     try {
       let produtoSalvo;
       if (id) {
-        const { data } = await api.put(`${API_PREFIX}/produtos/${id}`, payload);
+        const { data } = await api.put(`${API_URL}/produtos/${id}`, payload);
         produtoSalvo = data;
       } else {
-        const { data } = await api.post(`${API_PREFIX}/produtos`, payload);
+        const { data } = await api.post(`${API_URL}/produtos`, payload);
         produtoSalvo = data;
       }
 
@@ -283,7 +283,7 @@ export default function Cadastro() {
       return;
     }
     try {
-      await api.delete(`${API_PREFIX}/produtos/${itemDelete.id}`);
+      await api.delete(`${API_URL}/produtos/${itemDelete.id}`);
       setIngredientes(prev => prev.filter(item => item.id !== itemDelete.id));
     } catch (err) {
       alert("Erro ao excluir produto!");
@@ -322,7 +322,7 @@ export default function Cadastro() {
         }
       }
 
-      const { data: result } = await api.post(`${API_PREFIX}/produtos/importar`, { produtos });
+      const { data: result } = await api.post(`${API_URL}/produtos/importar`, { produtos });
       if (result.erros && result.erros.length > 0) {
         alert(
           "Alguns produtos não foram importados:\n" +
@@ -370,7 +370,7 @@ export default function Cadastro() {
   async function handleToggleAtivo(item) {
     setAtivandoId(item.id);
     try {
-      const { data: produtoAtualizado } = await api.put(`${API_PREFIX}/produtos/${item.id}`, {
+      const { data: produtoAtualizado } = await api.put(`${API_URL}/produtos/${item.id}`, {
         ...item,
         ativo: !item.ativo,
       });

--- a/src/components/Estoque/EntradaEstoque.jsx
+++ b/src/components/Estoque/EntradaEstoque.jsx
@@ -4,7 +4,7 @@ import ModalCadastroFornecedor from "./ModalCadastroFornecedor";
 import ModalUpgradePlano from "../modals/ModalUpgradePlano";
 import { useAuth } from "../../App";
 import Select from "react-select";
-import { API_PREFIX } from "../../services/api";
+import { API_URL } from "../../services/api";
 import "./EntradaEstoque.css";
 
 // ====== ESTILO REACT-SELECT ======
@@ -128,7 +128,7 @@ export default function EntradaEstoque() {
 
   // Buscar produtos do backend
   useEffect(() => {
-    fetch(`${API_PREFIX}/produtos`)
+    fetch(`${API_URL}/produtos`)
       .then(res => res.json())
       .then(data => setProdutos(data))
       .catch(() => setMsg("Erro ao buscar produtos"));
@@ -136,7 +136,7 @@ export default function EntradaEstoque() {
 
   // Buscar fornecedores do backend
   useEffect(() => {
-    fetch(`${API_PREFIX}/fornecedores`, { credentials: "include" })
+    fetch(`${API_URL}/fornecedores`, { credentials: "include" })
       .then(res => res.json())
       .then(data => setFornecedores(data));
   }, []);
@@ -223,7 +223,7 @@ export default function EntradaEstoque() {
     try {
       for (const entrada of listaFinal) {
         if (!entrada.produtoId || !entrada.quantidade) continue;
-        await fetch(`${API_PREFIX}/produtos/entrada-estoque`, {
+        await fetch(`${API_URL}/produtos/entrada-estoque`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(entrada)
@@ -431,12 +431,12 @@ export default function EntradaEstoque() {
           ingrediente={novoProduto}
           onSave={async (novoProd) => {
             try {
-              await fetch(`${API_PREFIX}/produtos`, {
+              await fetch(`${API_URL}/produtos`, {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify(novoProd),
               });
-              const data = await fetch(`${API_PREFIX}/produtos`).then(r => r.json());
+              const data = await fetch(`${API_URL}/produtos`).then(r => r.json());
               setProdutos(data);
             } catch {
               alert("Erro ao cadastrar produto!");
@@ -484,12 +484,12 @@ export default function EntradaEstoque() {
               fornecedor={novoFornecedor}
               onSave={async (novoForn) => {
                 try {
-                  await fetch(`${API_PREFIX}/fornecedores`, {
+                  await fetch(`${API_URL}/fornecedores`, {
                     method: "POST",
                     headers: { "Content-Type": "application/json" },
                     body: JSON.stringify(novoForn),
                   });
-                  const data = await fetch(`${API_PREFIX}/fornecedores`, { credentials: "include" }).then(r => r.json());
+                  const data = await fetch(`${API_URL}/fornecedores`, { credentials: "include" }).then(r => r.json());
                   setFornecedores(data);
                   // Seleciona automaticamente o novo
                   const criado = data.find(f => f.cnpjCpf === novoForn.cnpjCpf && f.razaoSocial === novoForn.razaoSocial);

--- a/src/components/Estoque/Fornecedores.jsx
+++ b/src/components/Estoque/Fornecedores.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from "react";
 import ModalCadastroFornecedor from "./ModalCadastroFornecedor";
 import ModalUpgradePlano from "../modals/ModalUpgradePlano";
 import { useAuth } from "../../App";
-import { API_PREFIX } from "../../services/api";
+import { API_URL } from "../../services/api";
 import "./Fornecedores.css";
 
 export default function Fornecedores() {
@@ -33,7 +33,7 @@ export default function Fornecedores() {
   const [carregando, setCarregando] = useState(true);
   const [confirmExcluirIdx, setConfirmExcluirIdx] = useState(null);
 
-  const API = `${API_PREFIX}/fornecedores`;
+  const API = `${API_URL}/fornecedores`;
 
   useEffect(() => {
     fetch(API, { credentials: "include" })

--- a/src/components/Estoque/ImportarNotaFiscalXML.jsx
+++ b/src/components/Estoque/ImportarNotaFiscalXML.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { API_PREFIX } from "../../services/api";
+import { API_URL } from "../../services/api";
 
 export default function ImportarNotaFiscalXML({ onUpload }) {
   const [file, setFile] = useState(null);
@@ -22,7 +22,7 @@ export default function ImportarNotaFiscalXML({ onUpload }) {
     const formData = new FormData();
     formData.append("xml", file);
     try {
-      const res = await fetch(`${API_PREFIX}/produtos/importar-xml-nfe`, {
+      const res = await fetch(`${API_URL}/produtos/importar-xml-nfe`, {
         method: "POST",
         body: formData
       });

--- a/src/components/Estoque/ModalCadastroManual.jsx
+++ b/src/components/Estoque/ModalCadastroManual.jsx
@@ -9,7 +9,7 @@ import Select from "react-select";
 import { FaCog, FaPlus, FaEdit, FaTrash, FaCheck, FaTimes } from "react-icons/fa";
 import "./ModalCadastroManual.css";
 import { BsInfoCircle } from "react-icons/bs";
-import { API_PREFIX } from "../../services/api";
+import { API_URL } from "../../services/api";
 
 function formatarDataBR(dataStr) {
   if (!dataStr) return "";
@@ -109,7 +109,7 @@ async function buscarImagensPexels(nome, page = 1) {
 async function buscarNomePorCodigoBarras(codBarras) {
   if (!codBarras) return "";
   try {
-    const res = await fetch(`${API_PREFIX}/buscar-nome-codbarras/${codBarras}`);
+    const res = await fetch(`${API_URL}/buscar-nome-codbarras/${codBarras}`);
     if (!res.ok) return "";
     const data = await res.json();
     return data.nome || "";
@@ -242,7 +242,7 @@ export default function ModalCadastroManual({
   // Busca as opções SEMPRE que abrir o modal OU trocar para aba de rótulo
   useEffect(() => {
     if (open && abaBloco === "rotulo") {
-      fetch(`${API_PREFIX}/categorias-nutricionais`, { credentials: "include" })
+      fetch(`${API_URL}/categorias-nutricionais`, { credentials: "include" })
         .then(res => res.json())
         .then(data => setCategoriasNutricionais(Array.isArray(data) ? data : []));
     }
@@ -444,7 +444,7 @@ export default function ModalCadastroManual({
   useEffect(() => {
     if (abaBloco === "historico" && ingrediente?.id) {
       setLoadingEntradas(true);
-      fetch(`${API_PREFIX}/produtos/${ingrediente.id}/entradas`, { credentials: "include" })
+      fetch(`${API_URL}/produtos/${ingrediente.id}/entradas`, { credentials: "include" })
         .then(res => res.json())
         .then(data => setEntradas(Array.isArray(data) ? data : []))
         .catch(() => setEntradas([]))

--- a/src/components/Estoque/ModalConfiguracoesCadastro.jsx
+++ b/src/components/Estoque/ModalConfiguracoesCadastro.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from "react";
 import Modal from "react-modal";
 import { FiX } from "react-icons/fi";
 import { DragDropContext, Droppable, Draggable } from "@hello-pangea/dnd";
-import api, { API_PREFIX } from "../../services/api"; // <-- usa o axios central
+import api, { API_URL } from "../../services/api"; // <-- usa o axios central
 
 // Switch azul igual o do app
 function Switch({ checked, onChange }) {
@@ -59,7 +59,7 @@ export default function ModalConfiguracoesCadastro({ isOpen, onRequestClose }) {
 
     const userId = localStorage.getItem("user_id") || "1";
     api
-      .get(`${API_PREFIX}/preferencias/colunas-cadastro/${userId}`)
+      .get(`${API_URL}/preferencias/colunas-cadastro/${userId}`)
       .then(({ data }) => {
         if (Array.isArray(data) && data.length > 0)
           setColunas(data);
@@ -107,7 +107,7 @@ export default function ModalConfiguracoesCadastro({ isOpen, onRequestClose }) {
     setErro("");
     try {
       const userId = localStorage.getItem("user_id") || "1";
-      await api.post(`${API_PREFIX}/preferencias/colunas-cadastro`, { userId, colunas });
+      await api.post(`${API_URL}/preferencias/colunas-cadastro`, { userId, colunas });
       alert("Preferências salvas! (Agora no banco 😁)");
       onRequestClose();
     } catch (e) {

--- a/src/components/Estoque/Movimentacoes.jsx
+++ b/src/components/Estoque/Movimentacoes.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 import Select from "react-select";
 import ModalUpgradePlano from "../modals/ModalUpgradePlano";
 import { useAuth } from "../../App";
-import { API_PREFIX } from "../../services/api";
+import { API_URL } from "../../services/api";
 import "./Movimentacoes.css";
 
 // Estilo dos selects igual aos inputs do sistema
@@ -145,7 +145,7 @@ export default function Movimentacoes() {
   // Busca movimentações
   function buscarMovs() {
     setCarregando(true);
-    fetch(`${API_PREFIX}/movimentacoes`, { credentials: "include" })
+    fetch(`${API_URL}/movimentacoes`, { credentials: "include" })
       .then(res => res.json())
       .then(data => setMovs(data))
       .finally(() => setCarregando(false));
@@ -156,7 +156,7 @@ export default function Movimentacoes() {
   }, []);
 
   useEffect(() => {
-    fetch(`${API_PREFIX}/produtos`, { credentials: "include" })
+    fetch(`${API_URL}/produtos`, { credentials: "include" })
       .then(res => res.json())
       .then(setProdutos);
   }, []);
@@ -177,7 +177,7 @@ export default function Movimentacoes() {
 
     setDeletando(mov.id);
     try {
-      const rota = `${API_PREFIX}/movimentacoes/${mov.tipo === "entrada" ? "entrada" : "saida"}/${mov.id}`;
+      const rota = `${API_URL}/movimentacoes/${mov.tipo === "entrada" ? "entrada" : "saida"}/${mov.id}`;
       const res = await fetch(rota, { method: "DELETE", credentials: "include" });
       if (!res.ok) throw new Error("Erro ao deletar movimentação");
       buscarMovs();

--- a/src/components/Estoque/SaidaEstoque.jsx
+++ b/src/components/Estoque/SaidaEstoque.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from "react";
 import Select from "react-select";
 import ModalUpgradePlano from "../modals/ModalUpgradePlano";
 import { useAuth } from "../../App";
-import { API_PREFIX } from "../../services/api";
+import { API_URL } from "../../services/api";
 import "./EntradaEstoque.css"; // Usa o mesmo CSS global do restante
 
 // ====== ESTILO REACT-SELECT (azul/padrão do app) ======
@@ -111,7 +111,7 @@ export default function SaidaEstoque() {
   const [carregando, setCarregando] = useState(false);
 
   useEffect(() => {
-    fetch(`${API_PREFIX}/produtos`)
+    fetch(`${API_URL}/produtos`)
       .then(res => res.json())
       .then(data => setProdutos(data))
       .catch(() => setMsg("Erro ao buscar produtos"));
@@ -184,7 +184,7 @@ export default function SaidaEstoque() {
     try {
       for (const saida of listaFinal) {
         if (!saida.produtoId || !saida.quantidade) continue;
-        await fetch(`${API_PREFIX}/produtos/saida-estoque`, {
+        await fetch(`${API_URL}/produtos/saida-estoque`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           credentials: "include",

--- a/src/components/Markup/MarkupIdeal.jsx
+++ b/src/components/Markup/MarkupIdeal.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import api, { API_PREFIX } from "../../services/api";
+import api, { API_URL } from "../../services/api";
 import AbasModal from "./AbasModal";
 import DespesasFixasModal from "./DespesasFixasModal";
 import EncargosSobreVendaModal from "./EncargosSobreVendaModal";
@@ -553,7 +553,7 @@ export default function MarkupIdeal({ calcularTotalFuncionarioObj }) {
 
     try {
       await api.put(
-        `${API_PREFIX}/markup-ideal/${bloco.id}`,
+        `${API_URL}/markup-ideal/${bloco.id}`,
         {
           markup: bloco.markup,
           markupIdeal: markupIdeal,
@@ -574,7 +574,7 @@ export default function MarkupIdeal({ calcularTotalFuncionarioObj }) {
   useEffect(() => {
     async function fetchFiltro() {
       try {
-        const res = await api.get(`${API_PREFIX}/filtro-faturamento`, { withCredentials: true });
+        const res = await api.get(`${API_URL}/filtro-faturamento`, { withCredentials: true });
         if (res.data?.filtro) {
           setMediaTipo(res.data.filtro);
         } else {
@@ -589,7 +589,7 @@ export default function MarkupIdeal({ calcularTotalFuncionarioObj }) {
   useEffect(() => {
     async function fetchFaturamentos() {
       try {
-        const res = await api.get(`${API_PREFIX}/sales-results`, { withCredentials: true });
+        const res = await api.get(`${API_URL}/sales-results`, { withCredentials: true });
         const lista = Array.isArray(res.data) ? res.data : [];
         setFaturamentoLista(lista);
         let listaFiltrada = mediaTipo === "all" ? lista : lista.slice(-Number(mediaTipo));
@@ -609,7 +609,7 @@ export default function MarkupIdeal({ calcularTotalFuncionarioObj }) {
   useEffect(() => {
     async function fetchBlocos() {
       try {
-        const response = await api.get(`${API_PREFIX}/markup-ideal`, { withCredentials: true });
+        const response = await api.get(`${API_URL}/markup-ideal`, { withCredentials: true });
         setBlocos(Array.isArray(response.data) ? response.data : []);
       } catch (err) {
         setBlocos([]);
@@ -617,7 +617,7 @@ export default function MarkupIdeal({ calcularTotalFuncionarioObj }) {
     }
     async function fetchDespesasFixas() {
       try {
-        const res = await api.get(`${API_PREFIX}/despesasfixas`, { withCredentials: true });
+        const res = await api.get(`${API_URL}/despesasfixas`, { withCredentials: true });
         if (Array.isArray(res.data)) {
           setDespesasFixasSubcats(res.data);
         } else if (res.data && Array.isArray(res.data.categorias)) {
@@ -640,7 +640,7 @@ export default function MarkupIdeal({ calcularTotalFuncionarioObj }) {
     }
     async function fetchFuncionarios() {
       try {
-        const res = await api.get(`${API_PREFIX}/folhapagamento/funcionarios`, { withCredentials: true });
+        const res = await api.get(`${API_URL}/folhapagamento/funcionarios`, { withCredentials: true });
         setFuncionarios(Array.isArray(res.data) ? res.data : []);
       } catch (err) {
         setFuncionarios([]);
@@ -653,7 +653,7 @@ export default function MarkupIdeal({ calcularTotalFuncionarioObj }) {
   useEffect(() => {
     async function fetchEncargos() {
       try {
-        const res = await api.get(`${API_PREFIX}/encargos-sobre-venda`, { withCredentials: true });
+        const res = await api.get(`${API_URL}/encargos-sobre-venda`, { withCredentials: true });
         if (res.data) {
           setEncargos(res.data);
           if (Array.isArray(res.data.outros)) setOutrosEncargos(res.data.outros);
@@ -669,7 +669,7 @@ export default function MarkupIdeal({ calcularTotalFuncionarioObj }) {
   useEffect(() => {
     async function fetchEncargos() {
       try {
-        const res = await api.get(`${API_PREFIX}/encargos-sobre-venda`, { withCredentials: true });
+        const res = await api.get(`${API_URL}/encargos-sobre-venda`, { withCredentials: true });
         if (res.data) {
           setEncargos(res.data);
           if (Array.isArray(res.data.outros)) setOutrosEncargos(res.data.outros);
@@ -690,7 +690,7 @@ export default function MarkupIdeal({ calcularTotalFuncionarioObj }) {
       const ativosPorBloco = {};
       await Promise.all(blocos.map(async (bloco, idx) => {
         try {
-          const res = await api.get(`${API_PREFIX}/bloco-ativos/${bloco.id}`, { withCredentials: true });
+          const res = await api.get(`${API_URL}/bloco-ativos/${bloco.id}`, { withCredentials: true });
           ativosPorBloco[idx] = res.data.ativos || {};
         } catch {
           ativosPorBloco[idx] = {};
@@ -705,7 +705,7 @@ export default function MarkupIdeal({ calcularTotalFuncionarioObj }) {
       if (modalConfigIdx === null || !blocos[modalConfigIdx]) return;
       const blocoId = blocos[modalConfigIdx].id;
       try {
-        const res = await api.get(`${API_PREFIX}/bloco-ativos/${blocoId}`, { withCredentials: true });
+        const res = await api.get(`${API_URL}/bloco-ativos/${blocoId}`, { withCredentials: true });
         setCustosAtivosPorBloco(prev => ({
           ...prev,
           [modalConfigIdx]: res.data.ativos || {}
@@ -759,7 +759,7 @@ export default function MarkupIdeal({ calcularTotalFuncionarioObj }) {
         totalEncargosReais: totalEncargosReais,
       };
       const response = await api.post(
-        `${API_PREFIX}/markup-ideal`,
+        `${API_URL}/markup-ideal`,
         blocoCompleto,
         { withCredentials: true }
       );
@@ -857,7 +857,7 @@ export default function MarkupIdeal({ calcularTotalFuncionarioObj }) {
       const bloco = blocos[idx];
       if (!bloco?.id) return;
       await api.put(
-        `${API_PREFIX}/markup-ideal/${bloco.id}`,
+        `${API_URL}/markup-ideal/${bloco.id}`,
         { nome: novoNome },
         { withCredentials: true }
       );
@@ -878,7 +878,7 @@ export default function MarkupIdeal({ calcularTotalFuncionarioObj }) {
     const bloco = blocos[idx];
     try {
       await api.delete(
-        `${API_PREFIX}/markup-ideal/${bloco.id}`,
+        `${API_URL}/markup-ideal/${bloco.id}`,
         { withCredentials: true }
       );
       setBlocos(blocos => blocos.filter((_, i) => i !== idx));
@@ -911,11 +911,11 @@ export default function MarkupIdeal({ calcularTotalFuncionarioObj }) {
       outrosEncargos || []
     );
     try {
-      await api.post(`${API_PREFIX}/bloco-ativos/${blocoId}`,
+      await api.post(`${API_URL}/bloco-ativos/${blocoId}`,
         { ativos: custosAtivosEdicao },
         { withCredentials: true }
       );
-      await api.put(`${API_PREFIX}/markup-ideal/${blocoId}`,
+      await api.put(`${API_URL}/markup-ideal/${blocoId}`,
         { totalEncargosReais },
         { withCredentials: true }
       );

--- a/src/components/Perfil.jsx
+++ b/src/components/Perfil.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import api, { API_PREFIX, BASE_URL } from "../services/api";
+import api, { API_URL, BASE_URL } from "../services/api";
 import ModalToast from "./modals/ModalToast";
 import PerfilLoginSenha from "./PerfilLoginSenha";
 import Cropper from "react-easy-crop";
@@ -235,7 +235,7 @@ export default function Perfil({ onLogout, abaInicial }) {
     async function fetchUser() {
       setLoading(true);
       try {
-        const { data } = await api.get(`${API_PREFIX}/users/me`);
+        const { data } = await api.get(`${API_URL}/users/me`);
         const avatar = pickAvatarFrom(data);
         setUser({ ...data, avatarUrl: avatar });
         setAvatarPreview(avatar || null);
@@ -257,7 +257,7 @@ export default function Perfil({ onLogout, abaInicial }) {
           semNumero: false,
         };
 
-        const resConfig = await api.get(`${API_PREFIX}/company-config`);
+        const resConfig = await api.get(`${API_URL}/company-config`);
         if (resConfig.data) {
           novoForm = {
             ...novoForm,
@@ -299,7 +299,7 @@ export default function Perfil({ onLogout, abaInicial }) {
     // Faz o upload
     const formData = new FormData();
     formData.append("avatar", cropped.blob, "avatar.png");
-    const { data } = await api.post(`${API_PREFIX}/users/me/avatar`, formData, {
+    const { data } = await api.post(`${API_URL}/users/me/avatar`, formData, {
       headers: { "Content-Type": "multipart/form-data" },
     });
 
@@ -378,13 +378,13 @@ export default function Perfil({ onLogout, abaInicial }) {
     setEditando(false);
     setLoading(true);
     try {
-      await api.put(`${API_PREFIX}/users/me`, {
+      await api.put(`${API_URL}/users/me`, {
         name: form.nome,
         cpf: form.cpf,
         telefone: form.telefone,
       });
 
-      await api.post(`${API_PREFIX}/company-config`, {
+      await api.post(`${API_URL}/company-config`, {
         companyName: form.empresaNome,
         cnpj: form.cnpj,
         phone: form.telefoneEmpresa,
@@ -426,7 +426,7 @@ export default function Perfil({ onLogout, abaInicial }) {
     try {
       // vamos salvar como caminho de frontend (/avatars/XYZ.png)
       const chosen = `/avatars/${preset.id}`;
-      await api.put(`${API_PREFIX}/users/me`, { avatarUrl: chosen });
+      await api.put(`${API_URL}/users/me`, { avatarUrl: chosen });
       setUser((prev) => ({ ...prev, avatarUrl: chosen }));
       setAvatarPreview(chosen);
       setToastMsg("Avatar atualizado!");

--- a/src/components/PerfilLoginSenha.jsx
+++ b/src/components/PerfilLoginSenha.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import api, { API_PREFIX } from "../services/api";
+import api, { API_URL } from "../services/api";
 
 export default function PerfilLoginSenha({ email }) {
   const [senha, setSenha] = useState("");
@@ -24,7 +24,7 @@ export default function PerfilLoginSenha({ email }) {
     }
 
     try {
-      const { data } = await api.post(`${API_PREFIX}/users/change-password`, {
+      const { data } = await api.post(`${API_URL}/users/change-password`, {
         senhaNova: senha,
       });
 

--- a/src/components/QuadroDeReceitas/AbaComposicaoReceita.jsx
+++ b/src/components/QuadroDeReceitas/AbaComposicaoReceita.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 import Select from "react-select";
 import { FaTrash } from "react-icons/fa";
 import "./AbaComposicaoReceita.css";
-import api, { API_PREFIX } from "../../services/api"; // <-- usa o cliente central (injeta Authorization)
+import api, { API_URL } from "../../services/api"; // <-- usa o cliente central (injeta Authorization)
 
 function formatarCustoUn(custo, unidade) {
   const val = Number(custo);
@@ -69,7 +69,7 @@ export default function AbaComposicaoReceita({
 
   async function fetchProdutosEstoque() {
     try {
-      const { data } = await api.get(`${API_PREFIX}/produtos`);
+      const { data } = await api.get(`${API_URL}/produtos`);
       setProdutosEstoque(Array.isArray(data) ? data : []);
     } catch {
       setProdutosEstoque([]);
@@ -78,7 +78,7 @@ export default function AbaComposicaoReceita({
 
   async function fetchTodasReceitas() {
     try {
-      const { data } = await api.get(`${API_PREFIX}/receitas`); // baseURL já é /api
+      const { data } = await api.get(`${API_URL}/receitas`); // baseURL já é /api
       setTodasReceitas(Array.isArray(data) ? data : []);
     } catch {
       setTodasReceitas([]);

--- a/src/components/QuadroDeReceitas/AbaProjecaoReceita.jsx
+++ b/src/components/QuadroDeReceitas/AbaProjecaoReceita.jsx
@@ -1,5 +1,5 @@
 import React, { useRef, useState, useEffect } from "react";
-import { API_PREFIX } from "../../services/api";
+import { API_URL } from "../../services/api";
 import { FaPlus, FaEdit, FaTrash, FaCalendarAlt } from "react-icons/fa";
 import "./AbaProjecaoReceita.css";
 
@@ -107,7 +107,7 @@ export default function AbaProjecaoReceita({
 
   async function fetchTiposProduto() {
     try {
-      const res = await fetch(`${API_PREFIX}/receitas/tipos-produto`, { credentials: "include" });
+      const res = await fetch(`${API_URL}/receitas/tipos-produto`, { credentials: "include" });
       const data = await res.json();
       setTiposProduto(
         Array.isArray(data)
@@ -121,7 +121,7 @@ export default function AbaProjecaoReceita({
 
   async function handleAddTipo(novoNome) {
     try {
-      const res = await fetch(`${API_PREFIX}/receitas/tipos-produto`, {
+      const res = await fetch(`${API_URL}/receitas/tipos-produto`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         credentials: "include",
@@ -142,7 +142,7 @@ export default function AbaProjecaoReceita({
     const tipo = tiposProduto[idx];
     if (!tipo) return;
     try {
-      const res = await fetch(`${API_PREFIX}/receitas/tipos-produto/${tipo.value}`, {
+      const res = await fetch(`${API_URL}/receitas/tipos-produto/${tipo.value}`, {
         method: "DELETE",
         credentials: "include",
       });
@@ -187,7 +187,7 @@ export default function AbaProjecaoReceita({
   }
   async function fetchProfissoesDiretas() {
     try {
-      const res = await fetch(`${API_PREFIX}/folhapagamento/funcionarios/profissoes-diretas`, { credentials: "include" });
+      const res = await fetch(`${API_URL}/folhapagamento/funcionarios/profissoes-diretas`, { credentials: "include" });
       const data = await res.json();
       setProfissoesDiretas(Array.isArray(data) ? data.map(cargo => ({ value: cargo, label: cargo })) : []);
     } catch (error) {
@@ -196,7 +196,7 @@ export default function AbaProjecaoReceita({
   }
   async function fetchCargosValorHora() {
     try {
-      const res = await fetch(`${API_PREFIX}/folhapagamento/funcionarios`, { credentials: "include" });
+      const res = await fetch(`${API_URL}/folhapagamento/funcionarios`, { credentials: "include" });
       const data = await res.json();
       const cargos = Array.isArray(data) ? data.map(f => ({ cargo: f.cargo, valorHora: calcularValorHoraFuncionario(f) })) : [];
       setCargosComValorHora(cargos);

--- a/src/components/QuadroDeReceitas/CentralReceitas.jsx
+++ b/src/components/QuadroDeReceitas/CentralReceitas.jsx
@@ -11,12 +11,13 @@ import { pdf } from "@react-pdf/renderer";
 import FichaTecnicaPDF from "./FichaTecnicaPDF";
 import ModalUpgradePlano from "../modals/ModalUpgradePlano";
 import { useAuth } from "../../App";
-import { API_PREFIX, BASE_URL } from "../../services/api";
+import { API_URL, BASE_URL } from "../../services/api";
 import "./CentralReceitas.css";
 
 /** Bases do backend vindas do .env */
 const BACKEND_URL = BASE_URL || import.meta.env.VITE_BACKEND_URL || "http://localhost:3000"; // usado para servir /uploads
 const api = (path) => `${BACKEND_URL}${path}`;
+const API_BASE = `${BACKEND_URL}${API_URL}`;
 
 const ABAS = [
   { label: "Composição", componente: AbaComposicaoReceita },
@@ -143,14 +144,14 @@ export default function CentralReceitas() {
 
   async function fetchReceitas() {
     try {
-      const res = await fetch(api(`${API_PREFIX}/receitas`), { credentials: "include" });
+      const res = await fetch(api(`${API_URL}/receitas`), { credentials: "include" });
       if (res.ok) setReceitas(await res.json());
     } catch {}
   }
 
   async function fetchBlocosMarkup() {
     try {
-      const res = await fetch(api(`${API_PREFIX}/markup-ideal`), { credentials: "include" });
+      const res = await fetch(api(`${API_URL}/markup-ideal`), { credentials: "include" });
       if (res.ok) setBlocosMarkup(await res.json());
     } catch {
       setBlocosMarkup([]);
@@ -159,10 +160,10 @@ export default function CentralReceitas() {
 
   async function fetchPerfil() {
     try {
-      const resUser = await fetch(api(`${API_PREFIX}/users/me`), { credentials: "include" });
+      const resUser = await fetch(api(`${API_URL}/users/me`), { credentials: "include" });
       const user = resUser.ok ? await resUser.json() : {};
 
-      const resConfig = await fetch(api(`${API_PREFIX}/company-config`), { credentials: "include" });
+      const resConfig = await fetch(api(`${API_URL}/company-config`), { credentials: "include" });
       const empresa = resConfig.ok ? await resConfig.json() : {};
 
       setPerfil({
@@ -222,7 +223,7 @@ export default function CentralReceitas() {
   async function confirmarDelete() {
     if (!receitaPraDeletar) return;
     try {
-      const res = await fetch(api(`${API_PREFIX}/receitas/${receitaPraDeletar.id}`), {
+      const res = await fetch(api(`${API_URL}/receitas/${receitaPraDeletar.id}`), {
         method: "DELETE",
         credentials: "include",
       });
@@ -402,7 +403,7 @@ export default function CentralReceitas() {
     if (selecionados.length === 0) return;
     for (const id of selecionados) {
       try {
-        await fetch(api(`${API_PREFIX}/receitas/${id}`), { method: "DELETE", credentials: "include" });
+        await fetch(api(`${API_URL}/receitas/${id}`), { method: "DELETE", credentials: "include" });
       } catch {}
     }
     await fetchReceitas();
@@ -484,14 +485,14 @@ export default function CentralReceitas() {
     try {
       let res;
       if (editandoId) {
-        res = await fetch(api(`${API_PREFIX}/receitas/${editandoId}`), {
+        res = await fetch(api(`${API_URL}/receitas/${editandoId}`), {
           method: "PUT",
           headers: { "Content-Type": "application/json" },
           credentials: "include",
           body: JSON.stringify(dadosReceita),
         });
       } else {
-        res = await fetch(api(`${API_PREFIX}/receitas`), {
+        res = await fetch(api(`${API_URL}/receitas`), {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           credentials: "include",

--- a/src/components/Sugestoes/Sugestoes.jsx
+++ b/src/components/Sugestoes/Sugestoes.jsx
@@ -1,6 +1,6 @@
 // src/pages/Sugestoes.jsx
 import React, { useState, useEffect } from "react";
-import { API_PREFIX } from "../../services/api";
+import { API_URL } from "../../services/api";
 
 const BACKEND_URL = import.meta.env.VITE_BACKEND_URL || "http://localhost:3000";
 
@@ -49,7 +49,7 @@ export default function Sugestoes() {
     setEnviando(true);
     try {
       const token = localStorage.getItem("token");
-      const res = await fetch(`${BACKEND_URL}${API_PREFIX}/sugestoes`, {
+      const res = await fetch(`${BACKEND_URL}${API_URL}/sugestoes`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/src/components/TabelaPlanos.jsx
+++ b/src/components/TabelaPlanos.jsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState } from "react";
-import api, { API_PREFIX } from "../services/api";
+import api, { API_URL } from "../services/api";
 
 // IDs de planos do Mercado Pago (exemplo; ajuste conforme seu backend)
 const planosMensal = {
@@ -65,7 +65,7 @@ export default function TabelaPlanos({ userEmail }) {
     try {
       setLoading(true);
       const { data } = await api.post(
-        `${API_PREFIX}/mercadopago/criar-assinatura`,
+        `${API_URL}/mercadopago/criar-assinatura`,
         { email, planoId },
         { withCredentials: true }
       );

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -1,6 +1,6 @@
 // src/context/AuthContext.jsx
 import React, { createContext, useContext, useEffect, useState, useMemo } from "react";
-import api, { API_PREFIX } from "../services/api"; // se seu alias "@" estiver configurado, pode usar "@/services/api"
+import api, { API_URL } from "../services/api"; // se seu alias "@" estiver configurado, pode usar "@/services/api"
 
 const AuthContext = createContext({
   user: null,
@@ -17,7 +17,7 @@ export function AuthProvider({ children }) {
   // Busca o usuário logado no mount
   const loadMe = async () => {
     try {
-      const { data } = await api.get(`${API_PREFIX}/users/me`);
+      const { data } = await api.get(`${API_URL}/users/me`);
       setUser(data);
     } catch (err) {
       setUser(null);
@@ -33,7 +33,7 @@ export function AuthProvider({ children }) {
 
   // Faz login, salva token e atualiza o usuário
   const login = async (email, password) => {
-    const { data } = await api.post(`${API_PREFIX}/users/login`, { email, password });
+    const { data } = await api.post(`${API_URL}/users/login`, { email, password });
     // salva o token para o interceptor injetar nos próximos requests
     try {
       localStorage.setItem("token", data?.token || "");
@@ -45,7 +45,7 @@ export function AuthProvider({ children }) {
   // Faz logout no backend e limpa o token local
   const logout = async () => {
     try {
-      await api.post(`${API_PREFIX}/users/logout`);
+      await api.post(`${API_URL}/users/logout`);
     } catch {}
     try {
       localStorage.removeItem("token");

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -3,24 +3,9 @@
 
 import axios from "axios";
 
-/**
- * Config do Vite:
- * - VITE_BACKEND_URL: ex. https://calculaai-backend.onrender.com
- * - VITE_API_PREFIX: ex. /api
- */
-const RAW_BASE_URL = import.meta?.env?.VITE_BACKEND_URL || "";
-const RAW_API_PREFIX = import.meta?.env?.VITE_API_PREFIX || "/api";
-
-// normaliza para evitar barras duplicadas
-const BASE_URL = String(RAW_BASE_URL).replace(/\/+$/, "");
-const API_PREFIX = String(RAW_API_PREFIX || "")
-  .replace(/^\/+/, "/") // garante uma barra inicial
-  .replace(/\/+$/, ""); // remove barras finais
-
-// base final: https://.../api
-const FINAL_BASE_URL = `${BASE_URL}${API_PREFIX}`;
-
-console.log("[API] FINAL_BASE_URL =", FINAL_BASE_URL);
+// Base do backend (opcional) e prefixo fixo da API
+const BASE_URL = (import.meta?.env?.VITE_BACKEND_URL || "").replace(/\/+$/, "");
+const API_URL = "/api"; // prefixo único das rotas da API
 
 /* Utilidades para pegar token (se você também persistir no localStorage/cookie) */
 function getCookie(name) {
@@ -50,9 +35,10 @@ function getToken() {
   }
 }
 
-/* Axios instance apontando DIRETO pro backend (Render) */
+/* Axios instance apontando para o mesmo host do frontend
+   (ou para VITE_BACKEND_URL, se definido) */
 const api = axios.create({
-  baseURL: FINAL_BASE_URL,
+  baseURL: BASE_URL,
   withCredentials: true, // envia/recebe cookies (SameSite=None; Secure)
   headers: {
     "Content-Type": "application/json",
@@ -103,4 +89,4 @@ api.interceptors.response.use(
 );
 
 export default api;
-export { BASE_URL, API_PREFIX, FINAL_BASE_URL };
+export { BASE_URL, API_URL };

--- a/src/services/categoriasApi.js
+++ b/src/services/categoriasApi.js
@@ -1,22 +1,22 @@
 // src/services/categoriasApi.js
-import api, { API_PREFIX } from "./api";
+import api, { API_URL } from "./api";
 
 export async function listarCategorias() {
-  const { data } = await api.get(`${API_PREFIX}/categorias`);
+  const { data } = await api.get(`${API_URL}/categorias`);
   return data;
 }
 
 export async function adicionarCategoria(nome) {
-  const { data } = await api.post(`${API_PREFIX}/categorias`, { nome });
+  const { data } = await api.post(`${API_URL}/categorias`, { nome });
   return data;
 }
 
 export async function deletarCategoria(id) {
-  const resp = await api.delete(`${API_PREFIX}/categorias/${id}`);
+  const resp = await api.delete(`${API_URL}/categorias/${id}`);
   return resp.status === 200 || resp.status === 204;
 }
 
 export async function editarCategoria(id, novoNome) {
-  const { data } = await api.put(`${API_PREFIX}/categorias/${id}`, { nome: novoNome });
+  const { data } = await api.put(`${API_URL}/categorias/${id}`, { nome: novoNome });
   return data;
 }

--- a/src/services/marcasApi.js
+++ b/src/services/marcasApi.js
@@ -1,22 +1,22 @@
 // src/services/marcasApi.js
-import api, { API_PREFIX } from "./api"; // <- usa o cliente axios central
+import api, { API_URL } from "./api"; // <- usa o cliente axios central
 
 export async function listarMarcas() {
-  const { data } = await api.get(`${API_PREFIX}/marcas`);
+  const { data } = await api.get(`${API_URL}/marcas`);
   return data;
 }
 
 export async function adicionarMarca(nome) {
-  const { data } = await api.post(`${API_PREFIX}/marcas`, { nome });
+  const { data } = await api.post(`${API_URL}/marcas`, { nome });
   return data;
 }
 
 export async function deletarMarca(id) {
-  const resp = await api.delete(`${API_PREFIX}/marcas/${id}`);
+  const resp = await api.delete(`${API_URL}/marcas/${id}`);
   return resp.status === 200 || resp.status === 204;
 }
 
 export async function editarMarca(id, novoNome) {
-  const { data } = await api.put(`${API_PREFIX}/marcas/${id}`, { nome: novoNome });
+  const { data } = await api.put(`${API_URL}/marcas/${id}`, { nome: novoNome });
   return data;
 }


### PR DESCRIPTION
## Summary
- centralize API_URL constant in api client
- update services and components to use API_URL without double prefix

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 109 errors, 16 warnings)


------
https://chatgpt.com/codex/tasks/task_e_68b346d0b1608333ad3d5c80e2c180c6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Profile: Added a preset avatar picker with six options, shown in a new modal. Selecting an avatar updates your profile instantly; existing upload/crop flow remains available.
* Refactor
  * Standardized API base path usage across the app to a new API URL, covering authentication, profile, inventory, costs, recipes, suggestions, and subscriptions. No functional changes expected.
* Chores
  * Updated service configuration to align with the new API base path approach for more consistent request handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->